### PR TITLE
Upgrades the blacklocus dependency from 0.3.5 to 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build
 .gradle
 gradle.properties
 .idea
+/.nb-gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: "jacoco"
 
 group = "com.damick"
 archivesBaseName = "dropwizard-metrics-cloudwatch"
-version = "0.1.6"
+version = "0.2.0"
 
 
 def sonatypeRepositoryUrl
@@ -69,8 +69,8 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 allprojects {
-  sourceCompatibility = 1.7
-  targetCompatibility = 1.7
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
 }
 
 task sourcesJar(type: Jar) {
@@ -151,10 +151,10 @@ repositories {
 }
 
 if (!project.hasProperty('dropwizVer')) {
-  ext.dropwizVer = '0.7.1'
+  ext.dropwizVer = '0.9.2'
 }
 
-ext.awsVer = '1.10.45'
+ext.awsVer = '1.10.57'
 
 dependencies {
 
@@ -165,8 +165,8 @@ dependencies {
   compile "com.amazonaws:aws-java-sdk-cloudwatch:$awsVer"
 
   compile "io.dropwizard:dropwizard-metrics:$dropwizVer"
-  compile "com.blacklocus:metrics-cloudwatch:0.3.5"
+  compile "com.blacklocus:metrics-cloudwatch:0.4.0"
 
-  testCompile 'junit:junit:4.11'
+  testCompile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
Hi @jdamick - We've been using this dropwizard plugin for a while and have noticed that there are occasional errors in the Cloudwatch logs like "The value 0 for parameter
MetricData.blah is invalid".  It turns out just revving your dependency on blacklocus from 0.3.5 to 0.4.0 solves the problem.  While I was at it, I revved a couple other versions to be the latest & greatest and called this version "0.2.0[-SNAPSHOT]".  If this looks good to you, would mind merging & release a 0.2.0 firm release to maven central?  Thanks!

Original commit message:

---

This should solve the problem of "The value 0 for parameter
MetricData.blah is invalid", fixed as part of this blacklocus release: https://github.com/blacklocus/metrics-cloudwatch/issues/13

While upgrading the blacklocus dependency, I also upgraded the Java (1.7
-> 1.8) and underlying AWS SDK version.  Those are probably big enough
changes to semantically count as a minor version upgrade from a 0.1.x to
a 0.2.x, so I revved this version to 0.2.0-SNAPSHOT before submitting it
to jdamick for consideration.
